### PR TITLE
Adding GetServerName and GetProtocol for the mono plugin

### DIFF
--- a/plugins/mono/uwsgi.cs
+++ b/plugins/mono/uwsgi.cs
@@ -101,6 +101,14 @@ namespace uwsgi {
 		public override int GetLocalPort() {
 			return Convert.ToInt32(GetServerVariable("SERVER_PORT"));
 		}
+		
+		public override string GetServerName() {
+			return GetServerVariable("SERVER_NAME");
+		}
+		
+		public override string GetProtocol() {
+			return GetServerVariable("REQUEST_SCHEME");
+		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern public override string GetQueryString();


### PR DESCRIPTION
Some .NET apps crashes without theese, as they are used by the UriBuilder somewhere in the internals of HttpRequest.

For example, refer to this: [HttpContext in mono repository](https://github.com/mono/mono/blob/d0069a948d89b5e3705a9d3d8a94a79be073c2cf/mcs/class/System.Web/System.Web/HttpRequest.cs#L219)
```csharp
url_components.Scheme = worker_request.GetProtocol ();
url_components.Host = worker_request.GetServerName ();
url_components.Port = worker_request.GetLocalPort ();
url_components.Path = path;
```
This value is used when calling HttpRequest.Url, which is in turn is used by the ASP.NET WebForms Validation classes (it needs the domain name to generate correctly).